### PR TITLE
Update blazingtext.ipynb Mecab 

### DIFF
--- a/NLP_Amazon_Review/BlazingText/blazingtext.ipynb
+++ b/NLP_Amazon_Review/BlazingText/blazingtext.ipynb
@@ -75,7 +75,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install mecab-python3\n",
+    "%pip install mecab-python3\n",
+    "%pip install unidic-lite\n",
     "import MeCab"
    ]
   },


### PR DESCRIPTION
Changed `!ipip `to `%pip `and add `unidic-lite.` Currently throws error without unidic.
See: https://github.com/SamuraiT/mecab-python3#common-issues